### PR TITLE
Add missing exception handling

### DIFF
--- a/src/not_cloud/zcl_excel_converter_salv_table.clas.abap
+++ b/src/not_cloud/zcl_excel_converter_salv_table.clas.abap
@@ -254,7 +254,7 @@ CLASS zcl_excel_converter_salv_table IMPLEMENTATION.
         IF <lv_display> = abap_false AND <lv_data> = abap_true.
           rv_result = abap_true.
         ENDIF.
-      CATCH cx_sy_create_data_error cx_sy_dyn_call_error.
+      CATCH cx_sy_create_data_error cx_sy_dyn_call_error cx_salv_bs_sc_runtime_info.
         rv_result = abap_false.
     ENDTRY.
 


### PR DESCRIPTION
Fixes shortdump in ZDEMO_EXCEL32 and custom programs if the ALV bind functionality is being used.
The dumps are caused by the missing handling of the exception CX_SALV_BS_SC_RUNTIME_INFO.